### PR TITLE
work with gulp-changed and fix bug with double build

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,20 @@ gulp.task('assemble', function() {
 
 ```js
 gulp.task('watch', function() {
-    compasm.watch('./assembly.json', gulp.series('assemble'));
+  compasm.watch('./assembly.json', gulp.series('assemble'));
+});
+```
+
+## Use with gulp-changed for incremental builds
+
+`gulp-component-assembler` provides it's own changed function that should be passed to `gulp-changed` as an option. This will properly detect whether the files in the assembly.json have changed.
+
+```js
+gulp.task('assemble', function() {
+  return gulp.src('./assembly.json')
+    .pipe(changed(dest, {hasChanged: compasm.hasChanged}))
+    .pipe(compasm.assemble())
+    .pipe(gulp.dest('./dist'))
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Then the component output file `myComponent.js` would include the contents of th
 
 >If the user does not provide a value for `localeFileName` then  `gulp-component-assembler`  attempts to use the value of `'strings'`. If files using that value do not exist then it attempts to use the value of the containing folder.
 
->One locale file is needed per language. *At this time, `2015-08-03`, we only support the two letter ([ISO-639-1](http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)) locale names, like `'en'`, `'fr'`, `'de'`, etc.*
+>One locale file is needed per language. *At this time, `2016-05-17`, we support the two letter ([ISO-639-1](http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)) locale names, like `'en'`, `'fr'`, `'de'`, etc. We also support four letter codes with fallback to two letter codes. For example, `'zh-cn'` and `'en-us'` are valid codes that fallback to `'zh'` and `'en'`.*
 
 >___TODO: Provide more information here___
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Here is the list of options and their description and usage:
 | **defaultLocale** | `defaultLocale:"en"` | Set the locale that your project will use as the default locale. If you do not provide the `defaultLocale` option then the default locale is set to `"en"`. `defaultLocale` is also the locale that is used if the user attempts to request a non-supported locale. |
 | **exposeLang** | `exposeLang:true/false` | If set to `true` then the language strings are also placed into a global object for access outside of the IIFE. The language strings will be added to `[globalObj].[assemblyName].lang` where `assemblyName` is the name of the assembly that is being created.<br/><br/>**See `globalObj`.** |
 | **externalLibName** | `externalLibName:"filename"` | Name for the external lib file. The default is `assembly-lib.js` and `assembly-lib-min.js`.<br/><br/>**See `useExternalLib`.** |
+| **externalLibPath** | `externalLibPath:"path/to/output/lib"` | Path to output the external lib file. The default is `./`.<br/><br/>**See `useExternalLib`.** |
 | **globalObj** | `globalObj:"objectToUse"` | This is an optional string that defines the global object that is used to expose the language string into the global scope. The default value is `"window.components"`.<br/><br/>If you are building servers-side components to run in node.js, then you would set this to `"global.components"` or something similar. _But be aware that this could become a problem if you are working with a server cluster._<br/><br/>Currently this is only used if you set the option `exposeLang` to `true`.  |
 | **iifeParams** | `iifeParams:paramsObject` | This is an optional object that contains the list of parameters used by the IIFE and the list of parameters passed into the IIFE. The default values are "window, document".<br/><br/> **See *Option: iifeParams* below.** |
 | **localeVar** | `localeVar:"window.locale"` | The default value for this options is `window.locale`. If your application uses some other variable to set the locale then you can supply it here like `window.myObj.locale`. If the defined variable name is undefined or does not exist then the locale is set to the value of the option `defaultLocale`.<br><br> **See `defaultLocale` above.** |
@@ -162,7 +163,8 @@ gulp.task('assemble', function() {
     .pipe(compasm.assemble({
           "defaultLocale": 'fr',
           "minTemplateWS": true,
-          "useExternalLib": true
+          "useExternalLib": true,
+          "externalLibPath": "js/"
         })
     .pipe(gulp.dest('./dist'))
     .pipe(uglify())

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-component-assembler",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "author": "Michael G Collins <intervalia@gmail.com>",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-component-assembler",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "author": "Michael G Collins <intervalia@gmail.com>",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-component-assembler",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "author": "Michael G Collins <intervalia@gmail.com>",
   "contributors": [
     {

--- a/plugins/oldSubAssemblies.js
+++ b/plugins/oldSubAssemblies.js
@@ -15,6 +15,6 @@ function convertOldAssembliesToNewSubs(params) {
 }
 
 module.exports = function(register, types) {
-  register(convertOldAssembliesToNewSubs, types.BEFORE, 'oldSubAssemblies');
+  register(convertOldAssembliesToNewSubs, types.BEFORE_ASSEMBLY, 'oldSubAssemblies');
 };
 module.exports.version = "2.0.0";

--- a/plugins/oldTemplates.js
+++ b/plugins/oldTemplates.js
@@ -45,9 +45,7 @@ function processOldTemplates(templatePath, hasTranslations, assemblyPath, option
   //console.log(" template file:", templatePath);
   if (fs.existsSync(templatePath)) {
     // add the template file to be watched
-    if (watcher.isWatching(assemblyPath)) {
-      watcher.addFile(templatePath, assemblyPath);
-    }
+    watcher.addFile(templatePath, assemblyPath);
 
     contents += processOneOldTemplate(templatePath, options);
 

--- a/src/hasChanged.js
+++ b/src/hasChanged.js
@@ -1,0 +1,51 @@
+var fs = require('fs');
+var path = require('path');
+
+function compareLastModifiedTime(stream, cb, basePath, sourceFile, targetPath) {
+  if (sourceFile.isNull()) {
+    cb(null, sourceFile);
+    return;
+  }
+
+  fs.stat(targetPath, function(err, targetStat) {
+    if (err) {
+      if (err.code === 'ENOENT') {
+        // try reading the file using the oldDest path
+        target = path.join(basePath, path.basename(basePath)+'.js');
+
+        if (target !== targetPath) {
+          return compareLastModifiedTime(stream, cb, basePath, sourceFile, target);
+        }
+        else {
+          stream.push(sourceFile);
+        }
+      }
+      else {
+        stream.emit('error', new gutil.PluginError('gulp-changed', err, {
+          fileName: sourceFile.path
+        }));
+
+        stream.push(sourceFile);
+      }
+    }
+
+    // file changed
+    else if (sourceFile.stat.mtime > targetStat.mtime) {
+      stream.push(sourceFile);
+    }
+
+    cb();
+  });
+}
+
+/**
+ * Use in conjunction with gulp-changed to properly compare the assembly.json file
+ * to it's output file.
+ * @see https://github.com/sindresorhus/gulp-changed#haschanged
+ */
+module.exports = function (stream, cb, sourceFile, targetPath) {
+  basePath = path.dirname(targetPath);
+  targetPath = path.join(path.dirname(basePath), path.basename(basePath)+'.js');
+
+  compareLastModifiedTime(stream, cb, basePath, sourceFile, targetPath);
+}

--- a/src/hasChanged.js
+++ b/src/hasChanged.js
@@ -1,5 +1,6 @@
 var fs = require('fs');
 var path = require('path');
+var gutil = require('gulp-util');
 
 function compareLastModifiedTime(stream, cb, basePath, sourceFile, targetPath) {
   if (sourceFile.isNull()) {
@@ -11,7 +12,7 @@ function compareLastModifiedTime(stream, cb, basePath, sourceFile, targetPath) {
     if (err) {
       if (err.code === 'ENOENT') {
         // try reading the file using the oldDest path
-        target = path.join(basePath, path.basename(basePath)+'.js');
+        var target = path.join(basePath, path.basename(basePath)+'.js');
 
         if (target !== targetPath) {
           return compareLastModifiedTime(stream, cb, basePath, sourceFile, target);
@@ -44,8 +45,8 @@ function compareLastModifiedTime(stream, cb, basePath, sourceFile, targetPath) {
  * @see https://github.com/sindresorhus/gulp-changed#haschanged
  */
 module.exports = function (stream, cb, sourceFile, targetPath) {
-  basePath = path.dirname(targetPath);
+  var basePath = path.dirname(targetPath);
   targetPath = path.join(path.dirname(basePath), path.basename(basePath)+'.js');
 
   compareLastModifiedTime(stream, cb, basePath, sourceFile, targetPath);
-}
+};

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,6 @@ var externalFuncs = require("./externalFunctions");
 var PluginError = require('gulp-util').PluginError;
 var plugin = require("./plugin");
 var PLUGIN_NAME = require("./pluginName");
-var watcher = require("./watcher");
 
 function assemble(options) {
   "use strict";
@@ -64,5 +63,6 @@ module.exports = {
   "assemble": assemble,
   "loadPlugin": plugin.load,
   "pluginTypes": plugin.types,
-  "watch": watcher.watch
+  "watch": require("./watcher").watch,
+  "hasChanged": require("./hasChanged")
 };

--- a/src/index.js
+++ b/src/index.js
@@ -43,9 +43,7 @@ function assemble(options) {
     if (firstTime && options.useExternalLib) {
       firstTime = false;
       var file2 = new gutil.File({
-        "base": file.base,
-        "cwd": file.cwd,
-        "path": path.join(path.dirname(file.path), options.externalLibName || "assembly-lib.js"),
+        "path": path.join(options.externalLibPath || "./", options.externalLibName || "assembly-lib.js"),
         "contents": new Buffer(externalFuncs.template(options))
       });
       this.push(file2);

--- a/src/locales.js
+++ b/src/locales.js
@@ -50,10 +50,17 @@ function processLocales(baseLocalePath, localeFileName, assemblyName, options) {
                   "  var locale, language, i, len = langKeys.length, lang = {};\n"+
                   "  locales = (typeof locales === 'string' ? [locales] : locales);\n"+
                   "  for (i = 0; i < locales.length; i++) {\n"+
-                  "    language = locales[i].split('-')[0];\n"+
+                  "    language = locales[i];\n"+
                   "    if (validLocales.indexOf(language) !== -1) {\n"+
                   "      locale = language;\n"+
                   "      break;\n"+
+                  "    } else {\n"+
+                  "      //Check if the first two characters are a valid locale\n"+
+                  "      language = locales[i].split('-')[0];\n"+
+                  "      if (validLocales.indexOf(language) !== -1) {\n"+
+                  "        locale = language;\n"+
+                  "        break;\n"+
+                  "      }\n"+
                   "    }\n"+
                   "  }\n"+
                   "  locale = locale || '" + options.locale + "';\n";

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,7 +4,9 @@ var types = {
   "BEFORE_JS_FILE": "BEFORE_JS_FILE",    // before each js file is processed
   "AFTER_JS_FILE": "AFTER_JS_FILE",      // after each js file is processed
   "AFTER_ASSEMBLY": "AFTER_ASSEMBLY",    // after each assembly file is processed
-  "AFTER": "AFTER"                       // after the entire file is processed
+  "AFTER": "AFTER",                      // after the entire file is processed
+
+  "JS_TRANSPILE": "JS_TRANSPILE"         // for each js file
 };
 
 var plugins = {};

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -6,7 +6,7 @@ var PLUGIN_NAME = require("./pluginName");
 
 function processOneScript(scriptPath, includeName, options, pluginParams) {
   var contents = "/*\n * Included File: " + includeName + "\n */\n";
-  var temp;
+  var temp, fileContents;
 
   // Process any BEFORE_JS_FILE plug-ins
   temp = plugin.process(plugin.types.BEFORE_JS_FILE, pluginParams);
@@ -18,7 +18,11 @@ function processOneScript(scriptPath, includeName, options, pluginParams) {
     contents += "console.warn('" + scriptPath + " does not match any file');";
   }
   else {
-    contents += fs.readFileSync(scriptPath, {"encoding": "utf-8"}).replace(/[\n\r]/g, "\n");
+    fileContents = fs.readFileSync(scriptPath, {"encoding": "utf-8"}).replace(/[\n\r]/g, "\n");
+
+    // Process any JS_TRANSPILE plug-ins
+    pluginParams.fileContents = fileContents;
+    contents += plugin.process(plugin.types.JS_TRANSPILE, pluginParams) || fileContents;
   }
 
   // Process any AFTER_JS_FILE plug-ins

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -8,22 +8,23 @@ function processOneScript(scriptPath, includeName, options, pluginParams) {
   var contents = "/*\n * Included File: " + includeName + "\n */\n";
   var temp;
 
-  if (!fs.existsSync(scriptPath)) {
-    return contents + "console.warn('" + scriptPath + " does not match any file');";
-  }
-
   // Process any BEFORE_JS_FILE plug-ins
   temp = plugin.process(plugin.types.BEFORE_JS_FILE, pluginParams);
   if (temp) {
     contents += temp + "\n\n";
   }
 
-  contents += fs.readFileSync(scriptPath, {"encoding": "utf-8"}).replace(/[\n\r]/g, "\n");
+  if (!fs.existsSync(scriptPath)) {
+    contents += "console.warn('" + scriptPath + " does not match any file');";
+  }
+  else {
+    contents += fs.readFileSync(scriptPath, {"encoding": "utf-8"}).replace(/[\n\r]/g, "\n");
+  }
 
   // Process any AFTER_JS_FILE plug-ins
   temp = plugin.process(plugin.types.AFTER_JS_FILE, pluginParams);
   if (temp) {
-    contents += temp;
+    contents += '\n\n' + temp;
   }
 
   return contents;

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -287,6 +287,8 @@ function fileChanged(event, file) {
  * @param {string} assemblyPath - Path of the assembly the file is associated with.
  */
 function addFile(filePath, assemblyPath) {
+  if (!fileWatcher) return;
+
   var absoluteFilePath = path.resolve(process.cwd(), filePath);
   var absoluteAssemblyPath = path.resolve(process.cwd(), assemblyPath);
 
@@ -313,6 +315,8 @@ function addFile(filePath, assemblyPath) {
  * @param {string} assemblyPath - Path to the assembly file.
  */
 function addAssembly(assemblyPath) {
+  if (!fileWatcher) return;
+
   var absoluteAssemblyPath = path.resolve(process.cwd(), assemblyPath);
   var assemblyDir = path.dirname(absoluteAssemblyPath);
   var assembly;
@@ -420,26 +424,8 @@ function watch(patterns, opt, task) {
   });
 }
 
-/**
- * Return true if the watcher has been turned on and is watching the given assembly.
- * @param {string} assemblyPath - Path to the assembly file.
- * @returns {boolean}
- */
-function isWatching(assemblyPath) {
-  var absoluteAssemblyPath = path.resolve(process.cwd(), assemblyPath);
-  var assemblyDir = path.dirname(absoluteAssemblyPath);
-
-  if (!fileWatcher) {
-    return false;
-  }
-
-  var watchedPaths = fileWatcher.getWatched();
-  return watchStarted && watchedPaths[assemblyDir];
-}
-
 module.exports = {
   "addFile": addFile,
   "addAssembly": addAssembly,
-  "watch": watch,
-  "isWatching": isWatching
+  "watch": watch
 };

--- a/test/specs/locales.test.js
+++ b/test/specs/locales.test.js
@@ -159,6 +159,36 @@ describe('\n    Testing the file locales.js', function () {
       should.deepEqual(getLang('en'), getLang(acceptLanguage));
     });
 
+    it('getLang() should return 4-letter codes when supported', function() {
+      var langKeys, langs, validLocales, lang, getLang;
+
+      var acceptLanguage = ['ca-de', 'fj-ja', 'zh-cn', 'de'];
+
+      /*
+        will add to scope:
+          variables: langKeys, langs, validLocales, lang
+          functions: getLang()
+      */
+      eval(locales.process(baseLocalePath, localeFileName, assemblyName, options));
+
+      should.deepEqual(getLang('zh-cn'), getLang(acceptLanguage));
+    });
+
+    it('getLang() should fallback to a 2-letter code when the 4-letter code is unsupported', function() {
+      var langKeys, langs, validLocales, lang, getLang;
+
+      var acceptLanguage = ['ca-de', 'fj-ja', 'zh', 'de'];
+
+      /*
+        will add to scope:
+          variables: langKeys, langs, validLocales, lang
+          functions: getLang()
+      */
+      eval(locales.process(baseLocalePath, localeFileName, assemblyName, options));
+
+      should.deepEqual(getLang('zh-cn'), getLang(acceptLanguage));
+    });
+
     it('lang should use "window.locale" if it exists', function() {
       var langKeys, langs, validLocales, lang, getLang;
 


### PR DESCRIPTION
add ability for assembler to know when an assembly has changed to use with `gulp-changed`. Also fix a bug that caused the task to be fired twice with one save. Also add ability for plugins to use JS_TRANSPILE